### PR TITLE
change the color of bounding boxes

### DIFF
--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -9,7 +9,7 @@ export const shapeStyle = {
   fontFamily:
     "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Helvetica, Arial, sans-serif",
   shapeBackground: "hsla(210, 16%, 93%, 0.2)",
-  shapeStrokeStyle: "#f8f9fa",
+  shapeStrokeStyle: "#ff0000",
   shapeShadowStyle: "hsla(210, 9%, 31%, 0.35)"
 };
 


### PR DESCRIPTION
1)White color bounding boxes are not visible in the light color image background.
2)variable for color of bounding boxes can help user to choose the color they want.